### PR TITLE
wide checking

### DIFF
--- a/test/naive-receiver/naive-receiver.challenge.js
+++ b/test/naive-receiver/naive-receiver.challenge.js
@@ -49,6 +49,6 @@ describe('[Challenge] Naive receiver', function () {
         ).to.be.equal(0);
         expect(
             await ethers.provider.getBalance(pool.address)
-        ).to.be.equal(ETHER_IN_POOL + ETHER_IN_RECEIVER);
+        ).to.be.above(ETHER_IN_POOL);
     });
 });


### PR DESCRIPTION
Hi there. I suggest you the change (may be could be better) to give players the opportunity to implement solutions that not just move the funds to the pool but to other contract. As you probably know, one solution to this game could be create another borrower contract that after the attack, take 9 ether, with 1 spent as fee. Checking in the old way don't give place for this solution.

regards!

Gaston